### PR TITLE
Added the syntax so a user can restart their gateway

### DIFF
--- a/docs/source/tips_and_faq.rst
+++ b/docs/source/tips_and_faq.rst
@@ -80,3 +80,15 @@ When you file an issue, please include:
 2) What command you ran
 3) What the output was
 4) What you expected to happen
+
+
+How do I restart my gateway?
+============================
+The command to restart your gateway is ``vlab power restart --name defaultGateway``.
+
+Why do users restart their gateway? It might work around the issue causing the following
+errors:
+(*your error might be slightly different, especially when a FQDN is part of the error message*)
+
+- ``Error: unable to find host user.vlab.local for /api/1/ipam/portmap``
+- ``Error: service unavailable``


### PR DESCRIPTION
Renders like this:
![image](https://user-images.githubusercontent.com/12264343/92531001-58075580-f1e2-11ea-961c-ac7546d7cc3c.png)
